### PR TITLE
Change sitefarm_seed profile source from BB to GH

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "ucdavis/sitefarm": {
       "type": "vcs",
-      "url": "git@bitbucket.org:ietwebdev/sitefarm.git"
+      "url": "git@github.com:ucdavis/sitefarm_seed.git"
     },
     "ucdavis/aggiefeed": {
       "type": "vcs",


### PR DESCRIPTION
I'm just taking a guess here that the `ietwebdev/sitefarm` repo corresponds to the install profile, now open-sourced on GitHub at [ucdavis/sitefarm_seed](https://github.com/ucdavis/sitefarm_seed). If that's not correct, please let me know.

This project also depends on the BitBucket `ietwebdev/sitefarm-theme-one` repo, which is not publicly available. Should this dependency be removed or replaced with the [starterkit subtheme](https://bitbucket.org/ietwebdev/sitefarm-theme-one-subtheme-starterkits), perhaps?