### PR TITLE
Fix shell quoting

### DIFF
--- a/.ci/deploy/pantheon/dev-multidev
+++ b/.ci/deploy/pantheon/dev-multidev
@@ -14,7 +14,7 @@ terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
 # Prepare for Pantheon
 composer run prepare-for-pantheon
 
-if [[ $CI_BRANCH != $DEFAULT_BRANCH ]]
+if [[ $CI_BRANCH != "$DEFAULT_BRANCH" ]]
 then
   # Create a new multidev environment (or push to an existing one)
   terminus -n build:env:create "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes
@@ -35,11 +35,11 @@ fi
 terminus -n drush "$TERMINUS_SITE.$TERMINUS_ENV" -- cr
 
 # Clear the environment cache
-terminus -n env:clear-cache $TERMINUS_SITE.$TERMINUS_ENV
+terminus -n env:clear-cache "$TERMINUS_SITE.$TERMINUS_ENV"
 
 # Ensure secrets are set
 terminus -n secrets:set "$TERMINUS_SITE.$TERMINUS_ENV" token "$GITHUB_TOKEN" --file='github-secrets.json' --clear --skip-if-empty
 
 # Delete old multidev environments associated
 # with a PR that has been merged or closed.
-terminus -n build:env:delete:pr $TERMINUS_SITE --yes
+terminus -n build:env:delete:pr "$TERMINUS_SITE" --yes

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 # These are yaml anchors, reused later
 x-bash-env-steps:
   - &bash_env_export export BASH_ENV="$BITBUCKET_CLONE_DIR/.bashrc"
-  - &bash_env_source source $BASH_ENV
+  - &bash_env_source source "$BASH_ENV"
 
 # This is a larger yaml anchor, reused for each pipeline
 default_steps: &default_steps
@@ -13,15 +13,15 @@ default_steps: &default_steps
           - docker
       script:
         - *bash_env_export
-        - export CI_BRANCH=${BITBUCKET_BRANCH:-master} && echo $CI_BRANCH
-        - export PR_NUMBER=$BITBUCKET_PR_ID && echo $PR_NUMBER
-        - export CI_PR_URL=https://bitbucket.org/$BITBUCKET_REPO_OWNER/$BITBUCKET_REPO_SLUG/pull-requests/$BITBUCKET_PR_ID && echo $CI_PR_URL
-        - export CI_BUILD_NUMBER=$BITBUCKET_BUILD_NUMBER && echo $CI_BUILD_NUMBER
-        - export CI_PROJECT_USERNAME=$BITBUCKET_REPO_OWNER && echo $CI_PROJECT_USERNAME
-        - export CI_PROJECT_REPONAME=$BITBUCKET_REPO_SLUG && echo $CI_PROJECT_REPONAME
-        - export CI_PROJECT_NAME=$BITBUCKET_REPO_FULL_NAME && echo $CI_PROJECT_NAME
+        - export CI_BRANCH="${BITBUCKET_BRANCH:-master}" && echo "$CI_BRANCH"
+        - export PR_NUMBER="$BITBUCKET_PR_ID" && echo "$PR_NUMBER"
+        - export CI_PR_URL="https://bitbucket.org/$BITBUCKET_REPO_OWNER/$BITBUCKET_REPO_SLUG/pull-requests/$BITBUCKET_PR_ID" && echo "$CI_PR_URL"
+        - export CI_BUILD_NUMBER="$BITBUCKET_BUILD_NUMBER" && echo "$CI_BUILD_NUMBER"
+        - export CI_PROJECT_USERNAME="$BITBUCKET_REPO_OWNER" && echo "$CI_PROJECT_USERNAME"
+        - export CI_PROJECT_REPONAME="$BITBUCKET_REPO_SLUG" && echo "$CI_PROJECT_REPONAME"
+        - export CI_PROJECT_NAME="$BITBUCKET_REPO_FULL_NAME" && echo "$CI_PROJECT_NAME"
         - /build-tools-ci/scripts/set-environment
-        - echo $TERMINUS_ENV
+        - echo "$TERMINUS_ENV"
       artifacts:
         - .bashrc
   - parallel:
@@ -121,11 +121,11 @@ pipelines:
           - docker
           - composer
         script:
-          - export CI_BRANCH=${BITBUCKET_BRANCH:-master} && echo $CI_BRANCH
-          - export CI_BUILD_NUMBER=$BITBUCKET_BUILD_NUMBER && echo $CI_BUILD_NUMBER
-          - export CI_PROJECT_USERNAME=$BITBUCKET_REPO_OWNER && echo $CI_PROJECT_USERNAME
-          - export CI_PROJECT_REPONAME=$BITBUCKET_REPO_SLUG && echo $CI_PROJECT_REPONAME
-          - export CI_PROJECT_NAME=$BITBUCKET_REPO_FULL_NAME && echo $CI_PROJECT_NAME
+          - export CI_BRANCH="${BITBUCKET_BRANCH:-master}" && echo "$CI_BRANCH"
+          - export CI_BUILD_NUMBER="$BITBUCKET_BUILD_NUMBER" && echo "$CI_BUILD_NUMBER"
+          - export CI_PROJECT_USERNAME="$BITBUCKET_REPO_OWNER" && echo "$CI_PROJECT_USERNAME"
+          - export CI_PROJECT_REPONAME="$BITBUCKET_REPO_SLUG" && echo "$CI_PROJECT_REPONAME"
+          - export CI_PROJECT_NAME="$BITBUCKET_REPO_FULL_NAME" && echo "$CI_PROJECT_NAME"
           - /build-tools-ci/scripts/set-environment
           - terminus -n auth:login --machine-token="$TERMINUS_TOKEN"
-          - set -e && terminus project:clu $TERMINUS_SITE
+          - set -e && terminus project:clu "$TERMINUS_SITE"


### PR DESCRIPTION
Note: the `export` builtin can be tricked with the syntax: `export FOO=$BAR` -- if `$BAR` is set to the string `value OTHERVAL=foo`, it'll end up setting and exporting two variables. This PR fixes that possibility by quoting: `export FOO="$BAR"`.

*(Note: `export "FOO=$BAR"` would be a correct fix too)*